### PR TITLE
Update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ outputs:
   data:
     description: "The output data"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Fixes https://github.com/teunmooij/yaml/issues/1

Node 16 is deprecated, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/